### PR TITLE
Updated PercentChange getter

### DIFF
--- a/SignalR.StockTicker/SignalR.StockTicker/SignalR.StockTicker/Stock.cs
+++ b/SignalR.StockTicker/SignalR.StockTicker/SignalR.StockTicker/Stock.cs
@@ -28,7 +28,7 @@ namespace Microsoft.AspNet.SignalR.StockTicker
         {
             get
             {
-                return (double)Math.Round(Change / Price, 4);
+                return (double)Math.Round(Change / DayOpen, 4);
             }
         }
 


### PR DESCRIPTION
Not SignalR specific, but the PercentChange property makes more sense to me in relation to the starting price then the current price given the current table headings. 
